### PR TITLE
feature/CXAR-920-distributed-skills

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Resolve git 7-chars sha
         id: git-sha7
         run: |
-          echo "SHA7=1.9.3-SNAPSHOT" >> $GITHUB_OUTPUT
+          echo "SHA7=1.9.4-SNAPSHOT" >> $GITHUB_OUTPUT
 #          echo "SHA7=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
   trivy-analyze-config:

--- a/agent-plane/agent-plane-protocol/README.md
+++ b/agent-plane/agent-plane-protocol/README.md
@@ -42,7 +42,7 @@ Add the following dependency to your control-plane artifact pom:
         <dependency>
             <groupId>io.catenax.knowledge.dataspace.edc.control-plane</groupId>
             <artifactId>agent-plane-protocol</artifactId>
-            <version>1.9.3-SNAPSHOT</version>
+            <version>1.9.4-SNAPSHOT</version>
         </dependency>
 ```
 

--- a/agent-plane/agent-plane-protocol/pom.xml
+++ b/agent-plane/agent-plane-protocol/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentConfig.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentConfig.java
@@ -24,7 +24,6 @@ public class AgentConfig {
     public static String VERBOSE_PROPERTY = "cx.agent.sparql.verbose";
     public static boolean DEFAULT_VERBOSE_PROPERTY = false;
     public static String DEFAULT_ACCESS_POINT = "api";
-
     public static String CONTROL_PLANE_MANAGEMENT = "cx.agent.controlplane.management";
     public static String CONTROL_PLANE_IDS = "cx.agent.controlplane.protocol";
     public static String BUSINESS_PARTNER_NUMBER = "edc.participant.id";
@@ -53,6 +52,9 @@ public class AgentConfig {
     public static int DEFAULT_READ_TIMEOUT=1080000;
 
     public static String CALLBACK_ENDPOINT="cx.agent.callback";
+
+    public static String DEFAULT_SKILL_CONTRACT_PROPERTY = "cx.agent.skill.contract.default";
+
 
     /**
      * references to EDC services
@@ -218,6 +220,13 @@ public class AgentConfig {
      */
     public Integer getCallTimeout() {
         return config.getInteger(CALL_TIMEOUT_PROPERTY,null);
+    }
+
+    /**
+     * @return default skill contract
+     */
+    public String getDefaultSkillContract() {
+        return config.getString(DEFAULT_SKILL_CONTRACT_PROPERTY);
     }
 
 }

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentExtension.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/AgentExtension.java
@@ -15,6 +15,7 @@ import org.eclipse.tractusx.agents.edc.http.transfer.AgentSourceFactory;
 import org.eclipse.tractusx.agents.edc.http.transfer.AgentSourceRequestParamsSupplier;
 import org.eclipse.tractusx.agents.edc.rdf.RDFStore;
 import org.eclipse.tractusx.agents.edc.service.DataspaceSynchronizer;
+import org.eclipse.tractusx.agents.edc.service.EdcSkillStore;
 import org.eclipse.tractusx.agents.edc.sparql.DataspaceServiceExecutor;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQueryProcessor;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQuerySerializerFactory;
@@ -145,7 +146,7 @@ public class AgentExtension implements ServiceExtension {
         SparqlQueryProcessor processor=new SparqlQueryProcessor(reg,monitor,config,rdfStore, typeManager);
 
         // stored procedure store and transport endpoint
-        SkillStore skillStore=new SkillStore();
+        ISkillStore skillStore=new EdcSkillStore(catalogService,typeManager,config);
         DelegationService delegationService=new DelegationService(agreementController,monitor,httpClient,typeManager);
         AgentController agentController=new AgentController(monitor,agreementController,config,processor,skillStore,delegationService);
         monitor.debug(String.format("Registering agent controller %s",agentController));

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/ISkillStore.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/ISkillStore.java
@@ -1,0 +1,47 @@
+//
+// EDC Data Plane Agent Extension Test
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
+package org.eclipse.tractusx.agents.edc;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+/**
+ * interface to a skill store
+ */
+public interface ISkillStore {
+
+    /**
+     * match a given asset
+     * @param key asset name
+     * @return matcher
+     */
+    static Matcher matchSkill(String key) {
+        return AgentExtension.SKILL_PATTERN.matcher(key);
+    }
+
+    /**
+     * check a given asset for being a skill
+     * @param key asset name
+     * @return whether the asset encodes a skill
+     */
+    boolean isSkill(String key);
+
+    /**
+     * register a skill
+     * @param key asset name
+     * @param skill skill text
+     * @return old skill text, if one was registered
+     */
+    String put(String key, String skill);
+
+    /**
+     * return the stored skill text
+     * @param key asset name
+     * @return optional skill text if registered
+     */
+    Optional<String> get(String key);
+}

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/AgentController.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/AgentController.java
@@ -6,6 +6,7 @@
 //
 package org.eclipse.tractusx.agents.edc.http;
 
+import org.eclipse.tractusx.agents.edc.ISkillStore;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQueryProcessor;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.*;
@@ -18,7 +19,6 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.tractusx.agents.edc.AgentConfig;
 import org.eclipse.tractusx.agents.edc.AgentExtension;
 import org.eclipse.tractusx.agents.edc.IAgreementController;
-import org.eclipse.tractusx.agents.edc.SkillStore;
 
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -39,7 +39,7 @@ public class AgentController {
     protected final Monitor monitor;
     protected final IAgreementController agreementController;
     protected final AgentConfig config;
-    protected final SkillStore skillStore;
+    protected final ISkillStore skillStore;
 
     // the actual Matchmaking Agent is a Fuseki engine
     protected final SparqlQueryProcessor processor;
@@ -52,7 +52,7 @@ public class AgentController {
      * @param config configuration
      * @param processor sparql processor
      */
-    public AgentController(Monitor monitor, IAgreementController agreementController, AgentConfig config, SparqlQueryProcessor processor, SkillStore skillStore, IDelegationService delegationService) {
+    public AgentController(Monitor monitor, IAgreementController agreementController, AgentConfig config, SparqlQueryProcessor processor, ISkillStore skillStore, IDelegationService delegationService) {
         this.monitor = monitor;
         this.agreementController = agreementController;
         this.config=config;
@@ -374,7 +374,7 @@ public class AgentController {
                 remoteUrl=matcher.group("url");
                 graph=matcher.group("graph");
             } else {
-                matcher=skillStore.matchSkill(asset);
+                matcher=ISkillStore.matchSkill(asset);
                 if(!matcher.matches()) {
                     return Response.status(Response.Status.BAD_REQUEST).build();
                 }

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
@@ -8,7 +8,7 @@ package org.eclipse.tractusx.agents.edc.http.transfer;
 
 import org.eclipse.edc.connector.dataplane.spi.pipeline.StreamResult;
 import org.eclipse.tractusx.agents.edc.AgentExtension;
-import org.eclipse.tractusx.agents.edc.SkillStore;
+import org.eclipse.tractusx.agents.edc.ISkillStore;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQueryProcessor;
 import okhttp3.Response;
 import org.eclipse.edc.connector.dataplane.http.params.HttpRequestFactory;
@@ -48,7 +48,7 @@ public class AgentSource implements DataSource {
     protected EdcHttpClient httpClient;
     protected boolean isTransfer;
     protected SparqlQueryProcessor processor;
-    protected SkillStore skillStore;
+    protected ISkillStore skillStore;
 
     protected DataFlowRequest request;
 
@@ -85,7 +85,7 @@ public class AgentSource implements DataSource {
             if(graphMatcher.matches()) {
                 graph=asset;
             }
-            Matcher skillMatcher=SkillStore.matchSkill(asset);
+            Matcher skillMatcher= ISkillStore.matchSkill(asset);
             if(skillMatcher.matches()) {
                 skill=asset;
             }
@@ -212,7 +212,7 @@ public class AgentSource implements DataSource {
             return this;
         }
 
-        public AgentSource.Builder skillStore(SkillStore skillStore) {
+        public AgentSource.Builder skillStore(ISkillStore skillStore) {
             dataSource.skillStore=skillStore;
             return this;
         }

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSourceFactory.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSourceFactory.java
@@ -7,7 +7,7 @@
 package org.eclipse.tractusx.agents.edc.http.transfer;
 
 import org.eclipse.tractusx.agents.edc.AgentProtocol;
-import org.eclipse.tractusx.agents.edc.SkillStore;
+import org.eclipse.tractusx.agents.edc.ISkillStore;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQueryProcessor;
 import org.eclipse.edc.connector.dataplane.http.params.HttpRequestFactory;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
@@ -25,7 +25,7 @@ public class AgentSourceFactory extends org.eclipse.edc.connector.dataplane.http
     final Monitor monitor;
     final EdcHttpClient httpClient;
     final SparqlQueryProcessor processor;
-    final SkillStore skillStore;
+    final ISkillStore skillStore;
     final HttpRequestFactory requestFactory;
 
 
@@ -38,7 +38,7 @@ public class AgentSourceFactory extends org.eclipse.edc.connector.dataplane.http
      * @param processor the query processor/sparql engine
      * @param skillStore store for skills
      */
-    public AgentSourceFactory(EdcHttpClient httpClient, AgentSourceRequestParamsSupplier supplier, Monitor monitor, HttpRequestFactory requestFactory, SparqlQueryProcessor processor, SkillStore skillStore) {
+    public AgentSourceFactory(EdcHttpClient httpClient, AgentSourceRequestParamsSupplier supplier, Monitor monitor, HttpRequestFactory requestFactory, SparqlQueryProcessor processor, ISkillStore skillStore) {
         super(httpClient,supplier,monitor,requestFactory);
         this.supplier=supplier;
         this.monitor=monitor;

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/jsonld/JsonLd.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/jsonld/JsonLd.java
@@ -1,3 +1,9 @@
+//
+// EDC Data Plane Agent Extension Test
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
 package org.eclipse.tractusx.agents.edc.jsonld;
 
 import jakarta.json.*;
@@ -5,8 +11,13 @@ import org.eclipse.tractusx.agents.edc.model.*;
 
 import java.io.StringReader;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+/**
+ * base facility to deal with EDC specific JSONLD structures
+ */
 public class JsonLd {
 
     public static DcatCatalog processCatalog(String cat) {
@@ -47,6 +58,15 @@ public class JsonLd {
 
     public static TransferProcess processTransferProcess(JsonObject response) {
         return new TransferProcess(processJsonLd(response,null));
+    }
+
+    public static List<Asset> processAssetList(String response) {
+        return processAssetList(Json.createReader(new StringReader(response)).readArray());
+    }
+    public static List<Asset> processAssetList(JsonArray response) {
+        return response.stream().map( responseObject ->
+                new Asset(processJsonLd(responseObject.asJsonObject(),null))
+        ).collect(Collectors.toList());
     }
 
     public static String asString(JsonValue value) {

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/Asset.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/Asset.java
@@ -1,0 +1,36 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+package org.eclipse.tractusx.agents.edc.model;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.tractusx.agents.edc.jsonld.JsonLdObject;
+
+import java.util.Map;
+
+/**
+ * represents an asset
+ */
+public class Asset extends JsonLdObject {
+
+    Map<String, JsonValue> publicProperties;
+    Map<String, JsonValue> privateProperties;
+
+    public Asset(JsonObject node) {
+        super(node);
+        this.publicProperties=node.getJsonObject("https://w3id.org/edc/v0.0.1/ns/properties");
+        this.privateProperties=node.getJsonObject("https://w3id.org/edc/v0.0.1/ns/privateProperties");
+    }
+
+    public Map<String, JsonValue> getPrivateProperties() {
+        return privateProperties;
+    }
+
+    public Map<String, JsonValue> getPublicProperties() {
+        return publicProperties;
+    }
+
+}

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/DcatCatalog.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/DcatCatalog.java
@@ -1,3 +1,8 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
 package org.eclipse.tractusx.agents.edc.model;
 
 import jakarta.json.JsonObject;
@@ -7,6 +12,9 @@ import org.eclipse.tractusx.agents.edc.jsonld.JsonLdObject;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * represents a dcat catalogue
+ */
 public class DcatCatalog extends JsonLdObject {
 
     List<DcatDataset> datasets=new ArrayList<>();

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/DcatDataset.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/DcatDataset.java
@@ -1,8 +1,16 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
 package org.eclipse.tractusx.agents.edc.model;
 
 import jakarta.json.JsonObject;
 import org.eclipse.tractusx.agents.edc.jsonld.JsonLdObject;
 
+/**
+ * represents a dcat data set
+ */
 public class DcatDataset extends JsonLdObject {
 
     OdrlPolicy policy;

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/IdResponse.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/IdResponse.java
@@ -1,12 +1,17 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
 package org.eclipse.tractusx.agents.edc.model;
 
 import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import org.eclipse.tractusx.agents.edc.jsonld.JsonLdObject;
 
-import java.util.ArrayList;
-import java.util.List;
-
+/**
+ * represents a response object
+ */
 public class IdResponse extends JsonLdObject {
 
     public IdResponse(JsonObject node) {

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/OdrlPolicy.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/model/OdrlPolicy.java
@@ -1,8 +1,17 @@
+//
+// EDC Data Plane Agent Extension Test
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+//
 package org.eclipse.tractusx.agents.edc.model;
 
 import jakarta.json.JsonObject;
 import org.eclipse.tractusx.agents.edc.jsonld.JsonLdObject;
 
+/**
+ * represents a policy
+ */
 public class OdrlPolicy extends JsonLdObject {
 
     public OdrlPolicy(JsonObject node) {

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/service/DataspaceSynchronizer.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/service/DataspaceSynchronizer.java
@@ -1,3 +1,8 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
 package org.eclipse.tractusx.agents.edc.service;
 
 import jakarta.json.Json;
@@ -56,6 +61,7 @@ public class DataspaceSynchronizer implements Runnable {
         assetPropertyMap.put("http://www.w3.org/ns/shacl#shapesGraph",NodeFactory.createURI("http://www.w3.org/ns/shacl#shapesGraph"));
         assetPropertyMap.put("https://w3id.org/catenax/ontology/common#isFederated",NodeFactory.createURI("https://w3id.org/catenax/ontology/common#isFederated"));
         assetPropertyMap.put("https://w3id.org/catenax/ontology/common#publishedUnderContract",NodeFactory.createURI("https://w3id.org/catenax/ontology/common#publishedUnderContract"));
+        assetPropertyMap.put("https://w3id.org/catenax/ontology/common#satisfiesRole",NodeFactory.createURI("https://w3id.org/catenax/ontology/common#satisfiesRole"));
     }
 
     /**
@@ -241,6 +247,7 @@ public class DataspaceSynchronizer implements Runnable {
                             case "http://www.w3.org/2000/01/rdf-schema#isDefinedBy":
                             case "http://www.w3.org/1999/02/22-rdf-syntax-ns#type":
                             case "https://w3id.org/catenax/ontology/common#isFederated":
+                            case "https://w3id.org/catenax/ontology/common#satisfiesRole":
                             case "https://w3id.org/catenax/ontology/common#implementsProtocol":
                                 String[] urls = pureProperty.split(",");
                                 for (String url : urls) {

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/service/EdcSkillStore.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/service/EdcSkillStore.java
@@ -1,0 +1,72 @@
+//
+// EDC Data Plane Agent Extension
+// See copyright notice in the top folder
+// See authors file in the top folder
+// See license file in the top folder
+package org.eclipse.tractusx.agents.edc.service;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.tractusx.agents.edc.AgentConfig;
+import org.eclipse.tractusx.agents.edc.ISkillStore;
+import org.eclipse.tractusx.agents.edc.jsonld.JsonLd;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Implements a skill store based on EDC assets
+ */
+public class EdcSkillStore implements ISkillStore {
+
+    DataManagement management;
+    TypeManager typeManager;
+    AgentConfig config;
+
+    public EdcSkillStore(DataManagement management, TypeManager typeManager, AgentConfig config) {
+        this.management=management;
+        this.typeManager=typeManager;
+        this.config=config;
+    }
+
+    @Override
+    public boolean isSkill(String key) {
+        return ISkillStore.matchSkill(key).matches();
+    }
+
+    @Override
+    public String put(String key, String skill) {
+        try {
+            return management.createOrUpdateSkill(
+                    key,
+                    "No name given",
+                    "No description given",
+                    "unknown version",
+                    config.getDefaultSkillContract(),
+                    "<https://w3id.org/catenax/ontology/core>",
+                    "all",
+                    true,
+                    typeManager.getMapper().writeValueAsString(TextNode.valueOf(skill))
+            ).getId();
+        } catch (IOException e) {
+           return null;
+        }
+    }
+
+    @Override
+    public Optional<String> get(String key) {
+        QuerySpec findAsset=QuerySpec.Builder.newInstance().filter(
+                List.of(new Criterion("https://w3id.org/edc/v0.0.1/ns/id","=",key),
+                        new Criterion("http://www.w3.org/1999/02/22-rdf-syntax-ns#type","=","cx-common:SkillAsset"))).build();
+        try {
+            return management.listAssets(findAsset).stream().findFirst().map( asset->
+                    JsonLd.asString(asset.getPrivateProperties().get("https://w3id.org/catenax/ontology/common#query"))
+            );
+        } catch(IOException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/service/InMemorySkillStore.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/service/InMemorySkillStore.java
@@ -4,17 +4,18 @@
 // See authors file in the top folder
 // See license file in the top folder
 //
-package org.eclipse.tractusx.agents.edc;
+package org.eclipse.tractusx.agents.edc.service;
+
+import org.eclipse.tractusx.agents.edc.ISkillStore;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
 
 /**
  * An in-memory store for local skills
  */
-public class SkillStore {
+public class InMemorySkillStore implements ISkillStore {
 
     // temporary local skill store
     final protected Map<String,String> skills=new HashMap<>();
@@ -22,16 +23,7 @@ public class SkillStore {
     /**
      * create the store
      */
-    public SkillStore() {
-    }
-
-    /**
-     * match a given asset
-     * @param key asset name
-     * @return matcher
-     */
-    public static Matcher matchSkill(String key) {
-        return AgentExtension.SKILL_PATTERN.matcher(key);
+    public InMemorySkillStore() {
     }
 
     /**
@@ -40,7 +32,7 @@ public class SkillStore {
      * @return whether the asset encodes a skill
      */
     public boolean isSkill(String key) {
-        return matchSkill(key).matches();
+        return ISkillStore.matchSkill(key).matches();
     }
 
     /**

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/http/TestAgentController.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/http/TestAgentController.java
@@ -7,6 +7,7 @@
 package org.eclipse.tractusx.agents.edc.http;
 
 import org.eclipse.tractusx.agents.edc.rdf.RDFStore;
+import org.eclipse.tractusx.agents.edc.service.InMemorySkillStore;
 import org.eclipse.tractusx.agents.edc.sparql.DataspaceServiceExecutor;
 import org.eclipse.tractusx.agents.edc.sparql.SparqlQueryProcessor;
 import okhttp3.*;
@@ -68,7 +69,7 @@ public class TestAgentController {
 
 
     SparqlQueryProcessor processor=new SparqlQueryProcessor(serviceExecutorReg,monitor,agentConfig,store, typeManager);
-    SkillStore skillStore=new SkillStore();
+    InMemorySkillStore skillStore=new InMemorySkillStore();
 
 
     DelegationService delegationService=new DelegationService(mockController,monitor,null,typeManager);

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/service/TestDataspaceSynchronizer.java
@@ -78,7 +78,7 @@ public class TestDataspaceSynchronizer {
                 .add("@id", "4bf62562-9026-4dcf-93b5-42ea0de25490")
                 .add("https://w3id.org/edc/v0.0.1/ns/id", "https://w3id.org/catenax/ontology/common#GraphAsset?test:ExampleAsset")
                 .add("https://w3id.org/edc/v0.0.1/ns/contenttype", "application/json, application/xml")
-                .add("https://w3id.org/edc/v0.0.1/ns/version", "1.9.3-SNAPSHOT")
+                .add("https://w3id.org/edc/v0.0.1/ns/version", "1.9.4-SNAPSHOT")
                 .add("https://w3id.org/edc/v0.0.1/ns/name", "Test Asset")
                 .add("https://w3id.org/edc/v0.0.1/ns/description", "Test Asset for RDF Representation")
                 .add("https://w3id.org/catenax/ontology/common#publishedUnderContract", "<https://w3id.org/catenax/ontology/common#Contract?test:Contract>")
@@ -168,7 +168,7 @@ public class TestDataspaceSynchronizer {
                 "                },\n" +
                 "                \"dcat:accessService\": \"ddd4b79e-f785-4e71-9fe5-4a177b3ccf54\"\n" +
                 "            },\n" +
-                "            \"edc:version\": \"1.9.3-SNAPSHOT\",\n" +
+                "            \"edc:version\": \"1.9.4-SNAPSHOT\",\n" +
                 "            \"http://www.w3.org/2000/01/rdf-schema#isDefinedBy\": \"<https://w3id.org/catenax/ontology/diagnosis>\",\n" +
                 "            \"edc:name\": \"Diagnostic Trouble Code Catalogue Version 2022\",\n" +
                 "            \"http://www.w3.org/ns/shacl#shapeGraph\": \"@prefix cx-common: <https://w3id.org/catenax/ontology/common#>. \\n@prefix : <https://w3id.org/catenax/ontology/common#GraphAsset?oem:Diagnosis2022> .\\n@prefix cx-diag: <https://w3id.org/catenax/ontology/diagnosis#> .\\n@prefix owl: <http://www.w3.org/2002/07/owl#> .\\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\\n@prefix sh: <http://www.w3.org/ns/shacl#> .\\n\\n:OemDTC rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DTC ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:version ;\\n        sh:hasValue 0^^xsd:long ;\\n    ] ;\\n  sh:property [\\n        sh:path cx-diag:affects ;\\n        sh:class :OemDiagnosedParts ;\\n    ] ;\\n\\n:OemDiagnosedParts rdf:type sh:NodeShape ;\\n  sh:targetClass cx-diag:DiagnosedPart ;\\n  sh:property [\\n        sh:path cx-diag:provisionedBy ;\\n        sh:hasValue <urn:bpn:legal:BPNL00000003COJN> ;\\n    ] ;\\n\",\n" +

--- a/agent-plane/agentplane-azure-vault/pom.xml
+++ b/agent-plane/agentplane-azure-vault/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/agentplane-hashicorp/pom.xml
+++ b/agent-plane/agentplane-hashicorp/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents.edc</groupId>
         <artifactId>agent-plane</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/agent-plane/pom.xml
+++ b/agent-plane/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>    
     </parent>
     <name>Tractus-X EDC Agent Plane</name>

--- a/charts/agent-connector/Chart.yaml
+++ b/charts/agent-connector/Chart.yaml
@@ -37,12 +37,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.3-SNAPSHOT
+version: 1.9.4-SNAPSHOT
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.9.3-SNAPSHOT"
+appVersion: "1.9.4-SNAPSHOT"
 home: https://github.com/catenax-ng/product-agents-edc/tree/main/charts/agent-connector
 sources:
   - https://github.com/catenax-ng/product-agents-edc/tree/main/charts/agent-connector

--- a/charts/agent-connector/README.md
+++ b/charts/agent-connector/README.md
@@ -1,6 +1,6 @@
 # agent-connector
 
-![Version: 1.9.3-SNAPSHOT](https://img.shields.io/badge/Version-1.9.3--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.3-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.3--SNAPSHOT-informational?style=flat-square)
+![Version: 1.9.4-SNAPSHOT](https://img.shields.io/badge/Version-1.9.3--SNAPSHOT-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.4-SNAPSHOT](https://img.shields.io/badge/AppVersion-1.9.3--SNAPSHOT-informational?style=flat-square)
 
 A Helm chart for Tractus-X Agent-Enabled Eclipse Data Space Connector
 
@@ -10,7 +10,7 @@ A Helm chart for Tractus-X Agent-Enabled Eclipse Data Space Connector
 
 ```shell
 helm repo add tractusx-edc https://eclipse-tractusx.github.io/charts/dev
-helm install my-release tractusx-edc/tractusx-connector --version 1.9.3-SNAPSHOT
+helm install my-release tractusx-edc/tractusx-connector --version 1.9.4-SNAPSHOT
 ```
 
 ## Source Code

--- a/common/auth-jwt/pom.xml
+++ b/common/auth-jwt/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.eclipse.tractusx.agents</groupId>
         <artifactId>edc</artifactId>
-        <version>1.9.3-SNAPSHOT</version>
+        <version>1.9.4-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.tractusx.agents</groupId>
     <artifactId>edc</artifactId>
-    <version>1.9.3-SNAPSHOT</version>
+    <version>1.9.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Tractus-X Knowledge Agents Dataspace EDC Extensions</name>
     <description>EDC-Related Artifacts for Federated Procedure Calls</description>


### PR DESCRIPTION
https://jira.catena-x.net/browse/KA-318 introduce an EDC control plane/catalogue based skill store. Align with the final standard

## WHAT

Implements a skill store by means of the EDC control plane asset list.

## WHY

Up to now, the skill store was in-memory to the data plane. So it was neither resident nor could it be looked up via the catalogue.


## FURTHER NOTES

did some more alignment with the final version of the standard